### PR TITLE
fix check.name parameter, as it was not used before

### DIFF
--- a/templates/service.json.j2
+++ b/templates/service.json.j2
@@ -29,7 +29,7 @@
         {
           "id": "{{ check.id | default(service.id) }}",
           {%- if check.type == "http" %}
-          "name": "{{ check.id | default(service.name) }} HTTP check",
+          "name": "{{ check.name | default(service.name) }} HTTP check",
           "http": {{ check.http | to_json }},
           "method": {{ check.method | default("GET") | to_json }},
           "tls_skip_verify": {{ check.tls_skip_verify | default(false) | to_json }},


### PR DESCRIPTION
but it's referred by many role usages, eg
![image](https://github.com/user-attachments/assets/07be26d2-e223-41e3-915e-e232e35bd6e5)

See:
https://github.com/search?q=org%3Astatus-im+infra-role-consul-service+checks+name+language%3Ayaml&type=code