### PR TITLE
bump failure tresholds to 1 min and 2 min respectively

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,8 +7,8 @@ consul_default_check_disabled: false
 consul_default_check_interval: '30s'
 consul_default_check_timeout: '2s'
 consul_default_success_before_passing: 0
-consul_default_failures_before_warning: 1
-consul_default_failures_before_critical: 2
+consul_default_failures_before_warning: 2
+consul_default_failures_before_critical: 4
 # List of services to define
 consul_services: []
 #  - id: 'my-service-1'


### PR DESCRIPTION
Having critical treshold so low as to trigger on even service restarts is resulting in a lot of flapping of alerts.

Part of effort to reduce alert noise:
- https://github.com/status-im/infra-hq/issues/178