### PR TITLE
docker: fix the check to use right key

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,7 @@ checks:
     type: docker
     # required, the ID of the container to run the check in
     docker_container_id: '1d88ad189f4'
-    shell: '/bin/bash'
-    script: '/app/local-check.py'
+    args: ['/bin/bash', '-c', '/app/local-check.py']
 ```
 
 The following variables are also available:

--- a/templates/service.json.j2
+++ b/templates/service.json.j2
@@ -48,8 +48,7 @@
           {%- elif check.type == "docker" %}
           "name": "{{ check.id | default(service.name) }} Docker check",
           "docker_container_id": {{ check.docker_container_id | to_json }},
-          "shell": {{ check.shell | to_json }},
-          "script": {{ check.script | to_json }},
+          "args":  {{ check.args | to_json }},
           {%- endif %}
           {%- if check.deregister_critical_service_after is defined %}
           "deregister_critical_service_after": {{ check.deregister_critical_service_after | to_json }},


### PR DESCRIPTION
'script' doesn't exist and need to use `args` list.